### PR TITLE
Add Spark Streaming piece of Data Pipeline

### DIFF
--- a/pipelines/kafka_spark_streaming_pipeline/README.md
+++ b/pipelines/kafka_spark_streaming_pipeline/README.md
@@ -41,7 +41,7 @@ Clone this repo via whatever method you prefer.
 - Create a set of **legacy** API credentials via https://www.coinbase.com/settings/api
     - Make sure to save the API key and secret key after API key generation, you won't be able to get them afterwards
 
-### Option 1: Set Credentials + Environment Locally
+### Option 1: Local Environment Setup
 - Update the `pipelines/kafka_spark_streaming_pipeline/set_local_coinbase_credentials.sh` file with the above API key and secret key
 - From the base of this repo, run the following commands on a terminal to get Kafka up and running:
     - `cd pipelines/kafka_spark_streaming_pipeline && bash docker_setup_mac.sh`
@@ -56,9 +56,12 @@ Clone this repo via whatever method you prefer.
         - *Note: the above Python script accepts a trading pair as an additional argument but defaults to "BTC-USD" if none is provided (like above)*
             - Run `python3 coinbase_data_producer.py -h` for additional usage info
             - TODO: Add functionality to query API and provide valid trading pair values for users
+    - You should now see data being queried from the Coinbase API and sent to the Kafka topic!
+- In a third terminal, navigate again to the base of this repo and run the following commands to parse the Kafka topic using Spark structured streaming:
+    - `source venv/bin/activate`
+    - `cd spark && spark-submit --packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.0 spark_process_trade_stream.py`
+    - You should now see Coinbase trading data appear as a dataframe!
 
-You should now see data being queried from the Coinbase API and sent to the Kafka topic!
-
-### Option 2: Set Credentials + Environment Via AWS
+### Option 2: AWS Environment Setup
 
 STILL TO DO

--- a/pipelines/kafka_spark_streaming_pipeline/README.md
+++ b/pipelines/kafka_spark_streaming_pipeline/README.md
@@ -53,6 +53,9 @@ Clone this repo via whatever method you prefer.
 - Run the data producer script in the second terminal
     - `source venv/bin/activate`
     - `cd kafka && python3 coinbase_data_producer.py trades`
+        - *Note: the above Python script accepts a trading pair as an additional argument but defaults to "BTC-USD" if none is provided (like above)*
+            - Run `python3 coinbase_data_producer.py -h` for additional usage info
+            - TODO: Add functionality to query API and provide valid trading pair values for users
 
 You should now see data being queried from the Coinbase API and sent to the Kafka topic!
 

--- a/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
@@ -15,7 +15,7 @@ import time
 from include.utils.helpers import CoinbaseAdvancedTraderAuth, get_aws_parameter
 
 # Define Kafka configurations
-default_trade_topic_name = 'coinbase_trades'
+default_trade_topic_name = 'coinbase_trades_raw_data'
 default_product_topic_name = 'coinbase_products'
 default_kafka_broker = '127.0.0.1:12345'
 

--- a/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
@@ -73,6 +73,7 @@ def fetch_coinbase_data_send_to_kafka(producer, url, topic_name) -> None:
 
 if __name__ == "__main__":
     # Grab command line arguments
+    # TODO: Parse endpoint args first and set proper attributes
     parser = argparse.ArgumentParser(description='Simple app that will keep querying the Coinbase Advanced Trader API (using legacy API credentials) at regular intervals (i.e. every 5 seconds).')
     parser.add_argument('endpoint', 
                         type=str,
@@ -120,6 +121,7 @@ if __name__ == "__main__":
         url = coinbase_endpoint_dict[args.endpoint]
 
         # Make request
+        # TODO: Make function to call Coinbase API and change or remove print statement below
         if args.endpoint == 'trades':
             url = url.format(product_id=args.tradingpair)
             r = requests.get(url, auth=auth)

--- a/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
@@ -64,6 +64,7 @@ if __name__ == "__main__":
     if args.endpoint == 'trades':
         url = url.format(product_id=args.tradingpair)
         topic_name = default_trade_topic_name
+        processing_function = process_trades_data
     else:
         # Must be 'products' or else script will not run
         #TODO: Implement code to process data from this endpoint
@@ -98,7 +99,7 @@ if __name__ == "__main__":
     while True:
         # Make request
         r = requests.get(url, auth=auth)
-        processed_data_payload = process_trades_data(r.text)
+        processed_data_payload = processing_function(r.text)
         producer.send(topic=topic_name, value=processed_data_payload, timestamp_ms=int(time.time()))
         print("Payload written to topic {topic}".format(topic=topic_name))
         time.sleep(sleep_interval)

--- a/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
@@ -127,6 +127,7 @@ if __name__ == "__main__":
             topic_name = default_trade_topic_name
             producer.send(topic=topic_name, value=processed_data_payload, timestamp_ms=int(time.time()))
             print("Payload written to topic {topic}:".format(topic=topic_name), processed_data_payload)
+            # TODO: Update code to allow sleep interval to be defined as a variable above
             time.sleep(5)
 
         else:

--- a/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
@@ -40,19 +40,11 @@ def process_trade_data(trade_data: str) -> str:
     * payload: A cleaned set of data to pass to Kafka
     """
 
-    # TODO: Update below to perform more advanced computation
-    # For now, we will just grab the first trade and its relevant info
+    # Minimal processing here; we want to write to Kafka as quickly as possible (and can use Spark to deduplicate as needed)
+    # In order to write to Kafka: remove the "trades" key, convert back to string and encode
     trade_dict = json.loads(trade_data)
-    trades = trade_dict['trades']
-    first_trade = trades[0]
-    first_trade_dict = {
-        "TradingPair":first_trade['product_id'],
-        "Price":first_trade['price'],
-        "Side":first_trade['side'],
-        "ShareAmount":first_trade['size'],
-        "TradeDateTime":first_trade['time']
-    }
-    payload = ("".join(str([first_trade_dict]))).encode('utf-8')
+    trades = str(trade_dict['trades'])
+    payload = trades.encode('utf-8')
     return payload
 
 

--- a/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
@@ -11,7 +11,7 @@ import sys
 import time
 
 # Helper functions
-from include.utils.helpers import CoinbaseAdvancedTraderAuth, get_aws_parameter
+from include.utils.helpers import CoinbaseAdvancedTraderAuth, get_aws_parameter, process_trades_data
 
 sleep_interval = 5 # In seconds
 
@@ -30,37 +30,6 @@ coinbase_endpoint_dict = {
     'products' : coinbase_products_endpoint,
     'trades' : coinbase_market_trades_endpoint
 }
-
-def process_trades_data(data: str) -> str:
-    """
-    Function to help process trade data into a viable format to be sent to Kafka
-    Args:
-    * data: raw string data in the form of a dictionary returned from the "market trades" Coinbase API endpoint
-
-    Returns:
-    * payload: A cleaned set of data to pass to Kafka
-    """
-
-    # Minimal processing here; we want to write to Kafka as quickly as possible (and can use Spark to deduplicate as needed)
-    # In order to write to Kafka: remove the "trades" key, convert back to string and encode
-
-    trade_dict = json.loads(data)
-    trades = str(trade_dict['trades'])
-    payload = trades.encode('utf-8')
-    
-    return payload
-
-
-def process_products_data(product_data: dict):
-    """
-    Function to help process products data into a viable format to be sent to Kafka
-    Args:
-    * product_data: raw data in the form of a dictionary returned from the "products" Coinbase API endpoint
-    
-    Returns:
-    * payload: A cleaned set of data to pass to Kafka
-    """
-    pass
 
 def fetch_coinbase_data_send_to_kafka(producer, url, topic_name) -> None:
     """

--- a/pipelines/kafka_spark_streaming_pipeline/kafka/include/utils/helpers.py
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka/include/utils/helpers.py
@@ -57,3 +57,34 @@ def get_aws_parameter(name: str, region: str, ssm: Optional[boto3.client] = None
     value = response['Parameter']['Value']
 
     return value
+
+def process_trades_data(data: str) -> str:
+    """
+    Function to help process trade data into a viable format to be sent to Kafka
+    Args:
+    * data: raw string data in the form of a dictionary returned from the "market trades" Coinbase API endpoint
+
+    Returns:
+    * payload: A cleaned set of data to pass to Kafka
+    """
+
+    # Minimal processing here; we want to write to Kafka as quickly as possible (and can use Spark to deduplicate as needed)
+    # In order to write to Kafka: remove the "trades" key, convert back to string and encode
+
+    trade_dict = json.loads(data)
+    trades = str(trade_dict['trades'])
+    payload = trades.encode('utf-8')
+
+    return payload
+
+
+def process_products_data(product_data: dict):
+    """
+    Function to help process products data into a viable format to be sent to Kafka
+    Args:
+    * product_data: raw data in the form of a dictionary returned from the "products" Coinbase API endpoint
+
+    Returns:
+    * payload: A cleaned set of data to pass to Kafka
+    """
+    pass

--- a/pipelines/kafka_spark_streaming_pipeline/kafka/include/utils/helpers.py
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka/include/utils/helpers.py
@@ -37,6 +37,7 @@ class CoinbaseAdvancedTraderAuth(AuthBase):
 
         return request
 
+# TODO: Move into separate "AWS" directory
 def get_aws_parameter(name: str, region: str, ssm: Optional[boto3.client] = None) -> str:
     '''
     Retreive a parameter from AWS Systems Manager Parameter Store by supplied name and region

--- a/pipelines/kafka_spark_streaming_pipeline/kafka_python_setup_mac.sh
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka_python_setup_mac.sh
@@ -40,8 +40,8 @@ fi
 
 # Install kafka CLI tool to create Kafka topics for our Coinbase data
 brew install kafka
-kafka-topics --create --bootstrap-server '127.0.0.1:12345' --topic coinbase_trades
-kafka-topics --create --bootstrap-server '127.0.0.1:12345' --topic coinbase_products
+kafka-topics --create --bootstrap-server '127.0.0.1:12345' --topic coinbase_trades_raw_data
+kafka-topics --create --bootstrap-server '127.0.0.1:12345' --topic coinbase_trade_aggregated_metrics
 
 # Set up python3 virtual environment, activate it and install requirements
 python3 -m venv venv && source venv/bin/activate && pip3 install -r requirements.txt 

--- a/pipelines/kafka_spark_streaming_pipeline/kafka_python_setup_mac.sh
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka_python_setup_mac.sh
@@ -39,6 +39,8 @@ else
 fi
 
 # Install kafka CLI tool to create Kafka topics for our Coinbase data
+# TODO: See if this step can be replaced by accessing the Kafka container terminal
+# Reference StackOverflow: https://stackoverflow.com/questions/30172605/how-do-i-get-into-a-docker-containers-shell
 brew install kafka
 kafka-topics --create --bootstrap-server '127.0.0.1:12345' --topic coinbase_trades_raw_data
 kafka-topics --create --bootstrap-server '127.0.0.1:12345' --topic coinbase_trade_aggregated_metrics

--- a/pipelines/kafka_spark_streaming_pipeline/spark/spark_process_trade_stream.py
+++ b/pipelines/kafka_spark_streaming_pipeline/spark/spark_process_trade_stream.py
@@ -33,7 +33,7 @@ spark = SparkSession \
 # Make console output less verbose by setting log level to WARN
 spark.sparkContext.setLogLevel("WARN")
 
-
+# TODO: See if "failOnDataLoss" parameter can be removed (or if there can be a "testing" vs "production" mode where the value is false and true, respectively)
 raw_data_stream = spark \
     .readStream \
     .format("kafka") \

--- a/pipelines/kafka_spark_streaming_pipeline/spark/spark_process_trade_stream.py
+++ b/pipelines/kafka_spark_streaming_pipeline/spark/spark_process_trade_stream.py
@@ -1,0 +1,29 @@
+from kafka import KafkaProducer
+from kafka.errors import KafkaError, KafkaTimeoutError
+from pyspark import SparkContext
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import explode
+from pyspark.streaming import StreamingContext
+
+kafka_topic = "coinbase_trades"
+kafka_server = "127.0.0.1:12345"
+
+spark = SparkSession \
+    .builder \
+    .appName("CoinbaseTradesDeduplication") \
+    .getOrCreate()
+
+df = spark \
+    .readStream \
+    .format("kafka") \
+    .option("kafka.bootstrap.servers", kafka_server) \
+    .option("subscribe", kafka_topic) \
+    .option("includeHeaders", "true") \
+    .load() \
+    .selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
+
+query = df.writeStream \
+    .format("console") \
+    .option("truncate","true") \
+    .start() \
+    .awaitTermination()

--- a/pipelines/kafka_spark_streaming_pipeline/spark/spark_process_trade_stream.py
+++ b/pipelines/kafka_spark_streaming_pipeline/spark/spark_process_trade_stream.py
@@ -2,11 +2,23 @@ from kafka import KafkaProducer
 from kafka.errors import KafkaError, KafkaTimeoutError
 from pyspark import SparkContext
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import explode
+from pyspark.sql.functions import from_json, inline
 from pyspark.streaming import StreamingContext
 
 kafka_topic = "coinbase_trades"
 kafka_server = "127.0.0.1:12345"
+kafka_topic_schema = "array<struct<trade_id:string,product_id:string,price:string,size:string,time:string,side:string,bid:string,ask:string>>"
+
+"""
+# Example output of data in the Kafka topic we are retrieving; we have to read it in as JSON with a declarative schema
+[{'trade_id': '603790709', 'product_id': 'BTC-USD', 'price': '52076.68', 'size': '0.00064681', 'time': '2024-02-16T02:35:40.784239Z', 'side': 'SELL', 'bid': '', 'ask': ''},
+{'trade_id': '603790708', 'product_id': 'BTC-USD', 'price': '52073.62', 'size': '0.00009312', 'time': '2024-02-16T02:35:39.787328Z', 'side': 'BUY', 'bid': '', 'ask': ''},
+...............
+...............
+...............
+{'trade_id': '603790705', 'product_id': 'BTC-USD', 'price': '52073.51', 'size': '0.05053829', 'time': '2024-02-16T02:35:39.680906Z', 'side': 'BUY', 'bid': '', 'ask': ''},
+{'trade_id': '603790704', 'product_id': 'BTC-USD', 'price': '52073.52', 'size': '0.002', 'time': '2024-02-16T02:35:39.680906Z', 'side': 'BUY', 'bid': '', 'ask': ''}]
+"""
 
 spark = SparkSession \
     .builder \
@@ -20,7 +32,10 @@ df = spark \
     .option("subscribe", kafka_topic) \
     .option("includeHeaders", "true") \
     .load() \
-    .selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
+    .selectExpr(
+        "inline(from_json(CAST(value AS string), '{schema}'))".format(schema=kafka_topic_schema)
+    )
+
 
 query = df.writeStream \
     .format("console") \


### PR DESCRIPTION
Added Pyspark file that:
- Reads in raw Coinbase data from Kafka topic
- Processes and aggregates data from Kafka topic in a Streaming DataFrame
- Writes the aggregated data to a new Kafka topic as its own stream

Also added instructions on how to run the file in the README as well as various TODO comments.

Tentative plan after this PR is merged is to:
- Persist the raw data the first Kafka topic to a Postgres DB for batch processing later
- Persist the aggregated data in the second Kafka topic to a caching layer and use as the source of truth for real time data for the current date
    - For simplicity sake, I may just use a separate table in Postgres to act as the caching layer