### PR TITLE
Hotfix for Python3.12 Python-Kafka Package Import

### DIFF
--- a/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
+++ b/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py
@@ -1,5 +1,13 @@
 # Script that queries Coinbase's API every 5 seconds, connects to the Kafka broker and writes the data to Kafka
 
+# Custom code to fix import issues with Kafka Python import from Python3.12 (https://stackoverflow.com/a/77588167)
+import sys, types
+
+m = types.ModuleType('kafka.vendor.six.moves', 'Mock module')
+setattr(m, 'range', range)
+sys.modules['kafka.vendor.six.moves'] = m
+# TODO: Remove above code chunk when possible
+
 from kafka import KafkaProducer
 from kafka.errors import KafkaError, KafkaTimeoutError
 

--- a/pipelines/kafka_spark_streaming_pipeline/spark/spark_process_trade_stream.py
+++ b/pipelines/kafka_spark_streaming_pipeline/spark/spark_process_trade_stream.py
@@ -1,5 +1,13 @@
 import time
 
+# Custom code to fix import issues with Kafka Python import from Python3.12 (https://stackoverflow.com/a/77588167)
+import sys, types
+
+m = types.ModuleType('kafka.vendor.six.moves', 'Mock module')
+setattr(m, 'range', range)
+sys.modules['kafka.vendor.six.moves'] = m
+# TODO: Remove above code chunk when possible
+
 from kafka import KafkaProducer
 from kafka.errors import KafkaError, KafkaTimeoutError
 from pyspark import SparkContext


### PR DESCRIPTION
After recreating the Python virtual environment recently, scripts began to fail with the following error:
```
(venv) fritteryerra@Fritters-MacBook-Air kafka % python3 coinbase_data_producer.py trades
Traceback (most recent call last):
  File "/Users/fritteryerra/workspace/personal/poc-data-pipelines/pipelines/kafka_spark_streaming_pipeline/kafka/coinbase_data_producer.py", line 11, in <module>
    from kafka import KafkaProducer
  File "/Users/fritteryerra/workspace/personal/poc-data-pipelines/pipelines/kafka_spark_streaming_pipeline/venv/lib/python3.12/site-packages/kafka/__init__.py", line 23, in <module>
    from kafka.consumer import KafkaConsumer
  File "/Users/fritteryerra/workspace/personal/poc-data-pipelines/pipelines/kafka_spark_streaming_pipeline/venv/lib/python3.12/site-packages/kafka/consumer/__init__.py", line 3, in <module>
    from kafka.consumer.group import KafkaConsumer
  File "/Users/fritteryerra/workspace/personal/poc-data-pipelines/pipelines/kafka_spark_streaming_pipeline/venv/lib/python3.12/site-packages/kafka/consumer/group.py", line 13, in <module>
    from kafka.consumer.fetcher import Fetcher
  File "/Users/fritteryerra/workspace/personal/poc-data-pipelines/pipelines/kafka_spark_streaming_pipeline/venv/lib/python3.12/site-packages/kafka/consumer/fetcher.py", line 19, in <module>
    from kafka.record import MemoryRecords
  File "/Users/fritteryerra/workspace/personal/poc-data-pipelines/pipelines/kafka_spark_streaming_pipeline/venv/lib/python3.12/site-packages/kafka/record/__init__.py", line 1, in <module>
    from kafka.record.memory_records import MemoryRecords, MemoryRecordsBuilder
  File "/Users/fritteryerra/workspace/personal/poc-data-pipelines/pipelines/kafka_spark_streaming_pipeline/venv/lib/python3.12/site-packages/kafka/record/memory_records.py", line 27, in <module>
    from kafka.record.legacy_records import LegacyRecordBatch, LegacyRecordBatchBuilder
  File "/Users/fritteryerra/workspace/personal/poc-data-pipelines/pipelines/kafka_spark_streaming_pipeline/venv/lib/python3.12/site-packages/kafka/record/legacy_records.py", line 50, in <module>
    from kafka.codec import (
  File "/Users/fritteryerra/workspace/personal/poc-data-pipelines/pipelines/kafka_spark_streaming_pipeline/venv/lib/python3.12/site-packages/kafka/codec.py", line 9, in <module>
    from kafka.vendor.six.moves import range
ModuleNotFoundError: No module named 'kafka.vendor.six.moves'
```


According to [this StackOverflow post](https://stackoverflow.com/a/77588167), the implemented workaround manually imports the non-existent package as a mock package that does nothing rather than causing the script to fail.

Added a TODO to remove the code as soon as the issue is resolved upstream.